### PR TITLE
Query Siteleaf versions API to generate list of supported plugins

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -56,7 +56,6 @@
       </div>
     </footer>
     <script src="//cdn.symbolset.com/5cf45762d90ee3c577c26afa495cccb24ad1f28d/symbolset.js"></script>
-    <script src="https://code.jquery.com/jquery-1.12.0.min.js"></script>
     <script src="/assets/js/main.js"></script>
   </body>
 </html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -56,5 +56,7 @@
       </div>
     </footer>
     <script src="//cdn.symbolset.com/5cf45762d90ee3c577c26afa495cccb24ad1f28d/symbolset.js"></script>
+    <script src="https://code.jquery.com/jquery-1.12.0.min.js"></script>
+    <script src="/assets/js/main.js"></script>
   </body>
 </html>

--- a/_theme-development/jekyll-plugins.markdown
+++ b/_theme-development/jekyll-plugins.markdown
@@ -1,6 +1,8 @@
 ---
 title: Jekyll Plugins
 date: 2016-03-24 12:15:00 -04:00
+position: 8
+layout: page
 ---
 
 Jekyll and GitHub Pages have support for a variety of external plugins, from [Coffeescript support](https://github.com/jekyll/jekyll-coffeescript) to [embeddable GitHub Gists](https://github.com/jekyll/jekyll-gist). We support the same subset of plugins that GitHub Pages supports.

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,31 +1,24 @@
-display_plugins = function() {
-  var data = $.ajax({
-    type: "GET",
-    url: "https://api.siteleaf.com/v2/versions",
-    error: function() {
-      console.log("could not load");
-    },
-    success: function(data) {
-      var list = document.querySelector('.supported-plugins')
-
-      if (list != null) {
-        for (var gem in data) {
-          var item = document.createElement('li');
-          item.innerHTML = '<a href="https://rubygems.org/gems/' + gem + '">' + gem + '</a>' + ' (' + data[gem] + ')';
-
-          list.appendChild(item);
-        }
-      }
-    }
-  });
-
-
+// Performs the request to get the plugins, then runs the display function
+load_plugins = function(list) {
+  var xhr = new XMLHttpRequest()
+  xhr.addEventListener('load', function () { display_plugins(list, JSON.parse(this.responseText)) })
+  xhr.open('GET', 'https://api.siteleaf.com/v2/versions')
+  xhr.send()
 };
 
-$(document).ready(function () {
+// Displays a list of plugins
+display_plugins = function(list, plugins) {
+  for (var gem in plugins) {
+    var item;
 
-  display_plugins();
+    item = document.createElement('li');
+    item.innerHTML = '<a href="https://rubygems.org/gems/' + gem + '">' + gem + '</a>' + ' (' + plugins[gem] + ')';
 
-  // load_plugins();
+    list.appendChild(item);
+  }
+}
 
-});
+var list = document.querySelector('.supported-plugins');
+if (list != null) {
+  load_plugins(list);
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,31 @@
+display_plugins = function() {
+  var data = $.ajax({
+    type: "GET",
+    url: "https://api.siteleaf.com/v2/versions",
+    error: function() {
+      console.log("could not load");
+    },
+    success: function(data) {
+      var list = document.querySelector('.supported-plugins')
+
+      if (list != null) {
+        for (var gem in data) {
+          var item = document.createElement('li');
+          item.innerHTML = '<a href="https://rubygems.org/gems/' + gem + '">' + gem + '</a>' + ' (' + data[gem] + ')';
+
+          list.appendChild(item);
+        }
+      }
+    }
+  });
+
+
+};
+
+$(document).ready(function () {
+
+  display_plugins();
+
+  // load_plugins();
+
+});


### PR DESCRIPTION
I wish I could've done it with vanilla JS, but I was running into an issue where I was getting an empty response instead of the JSON. `¯\_(ツ)_/¯`

(Closes #44)