### PR TITLE
Update link to Liquid documentation

### DIFF
--- a/_themes/liquid.markdown
+++ b/_themes/liquid.markdown
@@ -7,7 +7,7 @@ layout: page
 
 Liquid is an open-source templating language that was developed by [Shopify](http://shopify.com). It uses tags, objects, and filters to render out content into a theme.
 
-For an in-depth Liquid reference, check out the [official Liquid documentation](https://docs.shopify.com/themess/liquid-documentation/basics). For a full list of tags and filters, see [Shopify's Liquid for Designers](https://github.com/Shopify/liquid/wiki/Liquid-for-Designers) wiki.
+For an in-depth Liquid reference, check out the [official Liquid documentation](https://shopify.github.io/liquid/).
 
 ## Tags
 


### PR DESCRIPTION
The original link to Liquid documentation pointed to the Shopify help website, which includes a lot of Liquid info that's specific to Shopify. A better resource to replace both of the existing links might be the [new core Liquid documentation](https://shopify.github.io/liquid/), which only includes tags and filters that work outside of Shopify (such as on Jekyll sites).